### PR TITLE
fix: pad app containers to avoid bleed

### DIFF
--- a/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
+++ b/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
@@ -313,6 +313,21 @@ input {
 }
 
 /* ==============================================
+   APPLICATION CONTAINERS
+   Standard padding for top-level app wrappers
+   ============================================== */
+
+.container,
+.dealer-analytics-container,
+.pdf-container,
+.figma-container,
+.watchlist-container,
+.top-dealers-compact-container {
+    padding: var(--spacing-medium);
+    margin-bottom: var(--spacing-medium);
+}
+
+/* ==============================================
    DEALER WATCHLIST COMPONENT STYLES
    ============================================== */
 


### PR DESCRIPTION
## Summary
- add shared application container styles to ensure consistent padding and spacing between apps

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893c092faf88330b676ee21ebeaa6fb