### PR TITLE
feat: add daily notes component

### DIFF
--- a/BetaOne/force-app/main/default/lwc/dailyNotes/__tests__/dailyNotes.test.js
+++ b/BetaOne/force-app/main/default/lwc/dailyNotes/__tests__/dailyNotes.test.js
@@ -1,0 +1,23 @@
+import { createElement } from 'lwc';
+import DailyNotes from 'c/dailyNotes';
+
+describe('c-daily-notes', () => {
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+        localStorage.clear();
+    });
+
+    it('saves notes to localStorage on change', () => {
+        const element = createElement('c-daily-notes', { is: DailyNotes });
+        document.body.appendChild(element);
+
+        const textarea = element.shadowRoot.querySelector('lightning-textarea');
+        textarea.value = 'Test note';
+        textarea.dispatchEvent(new CustomEvent('change'));
+
+        const todayKey = `dailyNotes-${new Date().toISOString().slice(0, 10)}`;
+        expect(localStorage.getItem(todayKey)).toBe('Test note');
+    });
+});

--- a/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.html
+++ b/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.html
@@ -1,0 +1,12 @@
+<template>
+    <lightning-card title="Daily Notes">
+        <div class="slds-p-horizontal_medium">
+            <p class="slds-text-title_caps">{today}</p>
+            <lightning-textarea
+                label="Notes / Announcements"
+                value={notes}
+                onchange={handleChange}
+            ></lightning-textarea>
+        </div>
+    </lightning-card>
+</template>

--- a/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.js
+++ b/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.js
@@ -1,0 +1,21 @@
+import { LightningElement, track } from 'lwc';
+
+export default class DailyNotes extends LightningElement {
+    @track notes = '';
+    todayKey;
+
+    connectedCallback() {
+        const today = new Date().toISOString().slice(0, 10);
+        this.todayKey = `dailyNotes-${today}`;
+        this.notes = localStorage.getItem(this.todayKey) || '';
+    }
+
+    handleChange(event) {
+        this.notes = event.target.value;
+        localStorage.setItem(this.todayKey, this.notes);
+    }
+
+    get today() {
+        return new Date().toLocaleDateString();
+    }
+}

--- a/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.js-meta.xml
+++ b/BetaOne/force-app/main/default/lwc/dailyNotes/dailyNotes.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__AppPage,lightning__HomePage">
+            <supportedFormFactors>
+                <supportedFormFactor type="Large"/>
+                <supportedFormFactor type="Small"/>
+            </supportedFormFactors>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add a simple Daily Notes Lightning Web Component to serve as a notes/announcement tab for the day
- persist notes per day using browser local storage
- include basic unit test for note persistence

## Testing
- `npm run lint` *(fails: Restricted async operation "setTimeout" etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c18bd0e08330b7512c9dacbd18a6