### PR TITLE
feat: add simplified monthly goal chart component

### DIFF
--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.css
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.css
@@ -1,0 +1,9 @@
+.region-picker {
+  max-width: 200px;
+  margin-bottom: 1rem;
+}
+
+.chart-container {
+  position: relative;
+  height: 300px;
+}

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.html
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.html
@@ -1,0 +1,22 @@
+<template>
+  <lightning-card title="Monthly Goal">
+    <div class="slds-p-around_medium">
+      <template if:true={regionOptions}>
+        <lightning-combobox
+          class="region-picker"
+          variant="label-hidden"
+          value={selectedRegion}
+          options={regionOptions}
+          onchange={handleRegionChange}
+        >
+        </lightning-combobox>
+      </template>
+      <div class="chart-container">
+        <template if:true={isLoading}>
+          <lightning-spinner size="medium"></lightning-spinner>
+        </template>
+        <canvas class="goal-chart" lwc:dom="manual"></canvas>
+      </div>
+    </div>
+  </lightning-card>
+</template>

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
@@ -1,0 +1,121 @@
+import { LightningElement, track, wire } from "lwc";
+import { loadScript } from "lightning/platformResourceLoader";
+import chartjs from "@salesforce/resourceUrl/chartjs";
+import getSalesData from "@salesforce/apex/SalesDataService.getSalesData";
+import getRegions from "@salesforce/apex/SalesDataService.getRegions";
+
+export default class MonthlyGoalChart extends LightningElement {
+  @track regionOptions = [];
+  @track selectedRegion;
+  @track isLoading = true;
+  chart;
+  chartJsInitialized = false;
+
+  @wire(getRegions)
+  wiredRegions({ error, data }) {
+    if (data) {
+      this.regionOptions = data.map((r) => ({ label: r, value: r }));
+      this.selectedRegion = this.regionOptions[0]?.value;
+    } else if (error) {
+      // eslint-disable-next-line no-console
+      console.error("Error loading regions", error);
+      this.isLoading = false;
+    }
+  }
+
+  renderedCallback() {
+    if (this.chartJsInitialized) {
+      return;
+    }
+    this.chartJsInitialized = true;
+    loadScript(this, chartjs)
+      .then(() => {
+        const ctx = this.template
+          .querySelector("canvas.goal-chart")
+          .getContext("2d");
+        this.chart = new window.Chart(ctx, {
+          type: "line",
+          data: {
+            labels: [],
+            datasets: [
+              {
+                label: "Cumulative",
+                data: [],
+                borderColor: "#0066CC",
+                backgroundColor: "rgba(0,102,204,0.2)",
+                fill: true,
+                tension: 0.4,
+                pointRadius: 0
+              },
+              {
+                label: "Goal",
+                data: [],
+                borderColor: "#FF8A00",
+                borderDash: [5, 5],
+                fill: false,
+                pointRadius: 0,
+                borderWidth: 2
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { position: "bottom" }
+            },
+            scales: {
+              y: {
+                ticks: {
+                  callback: (value) =>
+                    "$" + new Intl.NumberFormat("en-US").format(value)
+                }
+              }
+            }
+          }
+        });
+        this.fetchData();
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error("Error loading Chart.js", error);
+        this.isLoading = false;
+      });
+  }
+
+  handleRegionChange(event) {
+    this.selectedRegion = event.detail.value;
+    this.fetchData();
+  }
+
+  fetchData() {
+    if (!this.selectedRegion) {
+      return;
+    }
+    this.isLoading = true;
+    getSalesData({ region: this.selectedRegion })
+      .then((result) => {
+        const cumulative = result.cumulativeData || {};
+        const goal = result.monthlyGoal || 0;
+        const now = new Date();
+        const daysInMonth = new Date(
+          now.getFullYear(),
+          now.getMonth() + 1,
+          0
+        ).getDate();
+        const labels = Array.from({ length: daysInMonth }, (_, i) => i + 1);
+        const cumulativeData = labels.map((day) => cumulative[day] || null);
+        this.chart.data.labels = labels;
+        this.chart.data.datasets[0].data = cumulativeData;
+        this.chart.data.datasets[1].data = Array(daysInMonth).fill(goal);
+        this.chart.update();
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error("Error getting sales data", error);
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
+  }
+}

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js-meta.xml
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add clean monthly goal chart LWC using existing SalesDataService
- visualize cumulative financing versus monthly goal with Chart.js

## Testing
- `npm test`
- `npm run lint` *(fails: Restricted async operation "setTimeout", etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894bbaa698c8330bda517398d644e50