### PR TITLE
feat: add account links to dealer watchlist

### DIFF
--- a/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.html
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.html
@@ -1,195 +1,257 @@
 <template>
-    <div class="watchlist-container app-container">
-        <!-- Modern Header Section -->
-        <div class="header-section">
-            <div class="header-content">
-                <div class="title-group">
-                    <div class="title-content">
-                        <h2 class="main-title">Dealer Watchlist</h2>
-                        <p class="banner-subtitle">{bannerSubtitle}</p>
-                    </div>
-                </div>
-            </div>
+  <div class="watchlist-container app-container">
+    <!-- Modern Header Section -->
+    <div class="header-section">
+      <div class="header-content">
+        <div class="title-group">
+          <div class="title-content">
+            <h2 class="main-title">Dealer Watchlist</h2>
+            <p class="banner-subtitle">{bannerSubtitle}</p>
+          </div>
         </div>
-
-        <!-- Controls Section -->
-        <div class="controls-section">
-            <div class="controls-row">
-                <!-- Region Filter -->
-                <div class="control-group">
-                    <label class="control-label">Region</label>
-                    <lightning-combobox
-                        name="region"
-                        value={selectedRegion}
-                        placeholder="Select Region"
-                        options={regionOptions}
-                        onchange={handleRegionChange}
-                        class="region-selector">
-                    </lightning-combobox>
-                </div>
-
-                <!-- Limit Filter -->
-                <div class="control-group">
-                    <label class="control-label">Results</label>
-                    <lightning-combobox
-                        name="limit"
-                        value={selectedLimit}
-                        placeholder="Select Limit"
-                        options={limitOptions}
-                        onchange={handleLimitChange}
-                        class="limit-selector">
-                    </lightning-combobox>
-                </div>
-
-                <!-- Comparison Type Toggle -->
-                <div class="control-group">
-                    <label class="control-label">Comparison</label>
-                    <div class="toggle-container">
-                        <lightning-input
-                            type="toggle"
-                            label={toggleLabel}
-                            checked={isYearOverYear}
-                            onchange={handleComparisonToggle}
-                            class="comparison-toggle">
-                        </lightning-input>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Content Section -->
-        <div class="content-section">
-            <!-- Loading Spinner -->
-            <template if:true={isLoading}>
-                <div class="loading-container">
-                    <lightning-spinner alternative-text="Loading dealer data..." size="medium"></lightning-spinner>
-                    <p class="loading-text">Loading dealer performance data...</p>
-                </div>
-            </template>
-
-            <!-- Main Content -->
-            <template if:false={isLoading}>
-                <!-- No Data State -->
-                <template if:true={hasNoData}>
-                    <div class="empty-state">
-                        <div class="empty-icon">
-                            <lightning-icon icon-name="utility:ban" size="large"></lightning-icon>
-                        </div>
-                        <h3 class="empty-title">No Performance Data Available</h3>
-                        <p class="empty-description">
-                            No dealer performance data is available for the selected region and comparison period.
-                            Try adjusting your filters or check back later.
-                        </p>
-                    </div>
-                </template>
-
-                <!-- Data Content -->
-                <template if:false={hasNoData}>
-                    <div class="performance-container">
-                        <div class="performance-grid">
-                            <!-- Winners Section -->
-                            <div class="performance-section winners-section">
-                                <div class="section-header winners-header">
-                                    <lightning-icon icon-name="utility:up" size="small" class="winners-icon"></lightning-icon>
-                                    <h4 class="section-title">Top Performers</h4>
-                                    <span class="section-count">({winnersCount})</span>
-                                </div>
-                                
-                                <template if:true={hasWinners}>
-                                    <div class="table-container">
-                                        <table class="dealer-table winners-table">
-                                            <thead>
-                                                <tr>
-                                                    <th>Dealer Name</th>
-                                                    <th class="text-right">{currentPeriodLabel}</th>
-                                                    <th class="text-right">{previousPeriodLabel}</th>
-                                                    <th class="text-right">Change</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <template for:each={winners} for:item="dealer" for:index="index">
-                                                    <tr key={dealer.name} class="dealer-row">
-                                                        <td class="dealer-name-cell">
-                                                            <div class="rank-number">{dealer.rank}</div>
-                                                            <span class="dealer-name" title={dealer.name}>
-                                                                {dealer.name}
-                                                            </span>
-                                                        </td>
-                                                        <td class="metric-cell text-right">{dealer.mtdText}</td>
-                                                        <td class="metric-cell text-right">{dealer.prevText}</td>
-                                                        <td class="delta-cell text-right">
-                                                            <span class="delta-value positive-delta">
-                                                                <lightning-icon icon-name="utility:up" size="xx-small"></lightning-icon>
-                                                                {dealer.deltaText}
-                                                            </span>
-                                                        </td>
-                                                    </tr>
-                                                </template>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </template>
-
-                                <template if:false={hasWinners}>
-                                    <div class="no-data-message">
-                                        <p>No top performers available</p>
-                                    </div>
-                                </template>
-                            </div>
-
-                            <!-- Losers Section -->
-                            <div class="performance-section losers-section">
-                                <div class="section-header losers-header">
-                                    <lightning-icon icon-name="utility:down" size="small" class="losers-icon"></lightning-icon>
-                                    <h4 class="section-title">Underperformers</h4>
-                                    <span class="section-count">({losersCount})</span>
-                                </div>
-                                
-                                <template if:true={hasLosers}>
-                                    <div class="table-container">
-                                        <table class="dealer-table losers-table">
-                                            <thead>
-                                                <tr>
-                                                    <th>Dealer Name</th>
-                                                    <th class="text-right">{currentPeriodLabel}</th>
-                                                    <th class="text-right">{previousPeriodLabel}</th>
-                                                    <th class="text-right">Change</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
-                                                <template for:each={losers} for:item="dealer" for:index="index">
-                                                    <tr key={dealer.name} class="dealer-row">
-                                                        <td class="dealer-name-cell">
-                                                            <div class="rank-number">{dealer.rank}</div>
-                                                            <span class="dealer-name" title={dealer.name}>
-                                                                {dealer.name}
-                                                            </span>
-                                                        </td>
-                                                        <td class="metric-cell text-right">{dealer.mtdText}</td>
-                                                        <td class="metric-cell text-right">{dealer.prevText}</td>
-                                                        <td class="delta-cell text-right">
-                                                            <span class="delta-value negative-delta">
-                                                                <lightning-icon icon-name="utility:down" size="xx-small"></lightning-icon>
-                                                                {dealer.deltaText}
-                                                            </span>
-                                                        </td>
-                                                    </tr>
-                                                </template>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </template>
-
-                                <template if:false={hasLosers}>
-                                    <div class="no-data-message">
-                                        <p>No underperformers available</p>
-                                    </div>
-                                </template>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-            </template>
-        </div>
+      </div>
     </div>
+
+    <!-- Controls Section -->
+    <div class="controls-section">
+      <div class="controls-row">
+        <!-- Region Filter -->
+        <div class="control-group">
+          <label class="control-label">Region</label>
+          <lightning-combobox
+            name="region"
+            value={selectedRegion}
+            placeholder="Select Region"
+            options={regionOptions}
+            onchange={handleRegionChange}
+            class="region-selector"
+          >
+          </lightning-combobox>
+        </div>
+
+        <!-- Limit Filter -->
+        <div class="control-group">
+          <label class="control-label">Results</label>
+          <lightning-combobox
+            name="limit"
+            value={selectedLimit}
+            placeholder="Select Limit"
+            options={limitOptions}
+            onchange={handleLimitChange}
+            class="limit-selector"
+          >
+          </lightning-combobox>
+        </div>
+
+        <!-- Comparison Type Toggle -->
+        <div class="control-group">
+          <label class="control-label">Comparison</label>
+          <div class="toggle-container">
+            <lightning-input
+              type="toggle"
+              label={toggleLabel}
+              checked={isYearOverYear}
+              onchange={handleComparisonToggle}
+              class="comparison-toggle"
+            >
+            </lightning-input>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Content Section -->
+    <div class="content-section">
+      <!-- Loading Spinner -->
+      <template if:true={isLoading}>
+        <div class="loading-container">
+          <lightning-spinner
+            alternative-text="Loading dealer data..."
+            size="medium"
+          ></lightning-spinner>
+          <p class="loading-text">Loading dealer performance data...</p>
+        </div>
+      </template>
+
+      <!-- Main Content -->
+      <template if:false={isLoading}>
+        <!-- No Data State -->
+        <template if:true={hasNoData}>
+          <div class="empty-state">
+            <div class="empty-icon">
+              <lightning-icon
+                icon-name="utility:ban"
+                size="large"
+              ></lightning-icon>
+            </div>
+            <h3 class="empty-title">No Performance Data Available</h3>
+            <p class="empty-description">
+              No dealer performance data is available for the selected region
+              and comparison period. Try adjusting your filters or check back
+              later.
+            </p>
+          </div>
+        </template>
+
+        <!-- Data Content -->
+        <template if:false={hasNoData}>
+          <div class="performance-container">
+            <div class="performance-grid">
+              <!-- Winners Section -->
+              <div class="performance-section winners-section">
+                <div class="section-header winners-header">
+                  <lightning-icon
+                    icon-name="utility:up"
+                    size="small"
+                    class="winners-icon"
+                  ></lightning-icon>
+                  <h4 class="section-title">Top Performers</h4>
+                  <span class="section-count">({winnersCount})</span>
+                </div>
+
+                <template if:true={hasWinners}>
+                  <div class="table-container">
+                    <table class="dealer-table winners-table">
+                      <thead>
+                        <tr>
+                          <th>Dealer Name</th>
+                          <th class="text-right">{currentPeriodLabel}</th>
+                          <th class="text-right">{previousPeriodLabel}</th>
+                          <th class="text-right">Change</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <template
+                          for:each={winners}
+                          for:item="dealer"
+                          for:index="index"
+                        >
+                          <tr key={dealer.name} class="dealer-row">
+                            <td class="dealer-name-cell">
+                              <div class="rank-number">{dealer.rank}</div>
+                              <template if:true={dealer.accountUrl}>
+                                <a
+                                  href={dealer.accountUrl}
+                                  target="_blank"
+                                  class="dealer-name"
+                                  title={dealer.name}
+                                  >{dealer.name}</a
+                                >
+                              </template>
+                              <template if:false={dealer.accountUrl}>
+                                <span class="dealer-name" title={dealer.name}
+                                  >{dealer.name}</span
+                                >
+                              </template>
+                            </td>
+                            <td class="metric-cell text-right">
+                              {dealer.mtdText}
+                            </td>
+                            <td class="metric-cell text-right">
+                              {dealer.prevText}
+                            </td>
+                            <td class="delta-cell text-right">
+                              <span class="delta-value positive-delta">
+                                <lightning-icon
+                                  icon-name="utility:up"
+                                  size="xx-small"
+                                ></lightning-icon>
+                                {dealer.deltaText}
+                              </span>
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
+                </template>
+
+                <template if:false={hasWinners}>
+                  <div class="no-data-message">
+                    <p>No top performers available</p>
+                  </div>
+                </template>
+              </div>
+
+              <!-- Losers Section -->
+              <div class="performance-section losers-section">
+                <div class="section-header losers-header">
+                  <lightning-icon
+                    icon-name="utility:down"
+                    size="small"
+                    class="losers-icon"
+                  ></lightning-icon>
+                  <h4 class="section-title">Underperformers</h4>
+                  <span class="section-count">({losersCount})</span>
+                </div>
+
+                <template if:true={hasLosers}>
+                  <div class="table-container">
+                    <table class="dealer-table losers-table">
+                      <thead>
+                        <tr>
+                          <th>Dealer Name</th>
+                          <th class="text-right">{currentPeriodLabel}</th>
+                          <th class="text-right">{previousPeriodLabel}</th>
+                          <th class="text-right">Change</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <template
+                          for:each={losers}
+                          for:item="dealer"
+                          for:index="index"
+                        >
+                          <tr key={dealer.name} class="dealer-row">
+                            <td class="dealer-name-cell">
+                              <div class="rank-number">{dealer.rank}</div>
+                              <template if:true={dealer.accountUrl}>
+                                <a
+                                  href={dealer.accountUrl}
+                                  target="_blank"
+                                  class="dealer-name"
+                                  title={dealer.name}
+                                  >{dealer.name}</a
+                                >
+                              </template>
+                              <template if:false={dealer.accountUrl}>
+                                <span class="dealer-name" title={dealer.name}
+                                  >{dealer.name}</span
+                                >
+                              </template>
+                            </td>
+                            <td class="metric-cell text-right">
+                              {dealer.mtdText}
+                            </td>
+                            <td class="metric-cell text-right">
+                              {dealer.prevText}
+                            </td>
+                            <td class="delta-cell text-right">
+                              <span class="delta-value negative-delta">
+                                <lightning-icon
+                                  icon-name="utility:down"
+                                  size="xx-small"
+                                ></lightning-icon>
+                                {dealer.deltaText}
+                              </span>
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
+                </template>
+
+                <template if:false={hasLosers}>
+                  <div class="no-data-message">
+                    <p>No underperformers available</p>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </div>
+        </template>
+      </template>
+    </div>
+  </div>
 </template>

--- a/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.js
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.js
@@ -1,174 +1,235 @@
 // Dealer Watchlist component handles UI logic and data interactions
-import { LightningElement, track } from 'lwc';
-import getDealerWinnersLosers from '@salesforce/apex/DealerWatchlistController.getDealerWinnersLosers';
-import getLastRegion from '@salesforce/apex/UserComponentPreferenceService.getLastRegion';
-import setLastRegion from '@salesforce/apex/UserComponentPreferenceService.setLastRegion';
-import { loadUnifiedStyles } from 'c/unifiedStylesHelper';
+import { LightningElement, track } from "lwc";
+import getDealerWinnersLosers from "@salesforce/apex/DealerWatchlistController.getDealerWinnersLosers";
+import findAccountByDealerName from "@salesforce/apex/TopDealersController.findAccountByDealerName";
+import getLastRegion from "@salesforce/apex/UserComponentPreferenceService.getLastRegion";
+import setLastRegion from "@salesforce/apex/UserComponentPreferenceService.setLastRegion";
+import { loadUnifiedStyles } from "c/unifiedStylesHelper";
 
-const COMPONENT_NAME = 'dealerWatchlist';
+const COMPONENT_NAME = "dealerWatchlist";
 
 export default class DealerWatchlist extends LightningElement {
-    @track watchlistData = [];
-    @track isLoading = false;
-    @track selectedRegion = 'Ontario';
-    @track selectedLimit = 10;
-    @track comparisonType = 'MonthOverMonth'; // New property for comparison type
-    
-    regionOptions = [
-        { label: 'Ontario', value: 'Ontario' },
-        { label: 'Alberta', value: 'Alberta' },
-        { label: 'Quebec', value: 'Quebec' },
-        { label: 'Atlantic', value: 'Atlantic' },
-        { label: 'Western', value: 'Western' }
-    ];
-    
-    limitOptions = [
-        { label: 'Top 5', value: 5 },
-        { label: 'Top 10', value: 10 },
-        { label: 'Top 15', value: 15 },
-        { label: 'Top 25', value: 25 }
-    ];
-    
-    // New getter for comparison type toggle
-    get isYearOverYear() {
-        return this.comparisonType === 'YearOverYear';
-    }
-    
-    get bannerSubtitle() {
-        const comparison = this.isYearOverYear ? 'YTD vs 2024 Comparison' : 'Month over Month Comparison';
-        return `Winners & Losers • Recreational Business Line • ${comparison}`;
-    }
-    
-    get toggleLabel() {
-        return this.isYearOverYear ? 'Year over Year' : 'Month over Month';
-    }
-    
-    async connectedCallback() {
-        // Load unified styles
-        await loadUnifiedStyles(this);
-        
-        getLastRegion({ componentName: COMPONENT_NAME })
-            .then(result => {
-                if (result && this.regionOptions.some(option => option.value === result)) {
-                    this.selectedRegion = result;
-                } else {
-                    this.selectedRegion = 'Ontario';
-                }
-                this.fetchWatchlistData();
-            })
-            .catch(error => {
-                console.error('Error getting last region:', error);
-                this.selectedRegion = 'Ontario';
-                this.fetchWatchlistData();
-            });
-    }
+  @track watchlistData = [];
+  @track isLoading = false;
+  @track selectedRegion = "Ontario";
+  @track selectedLimit = 10;
+  @track comparisonType = "MonthOverMonth"; // New property for comparison type
 
-    handleRegionChange(event) {
-        this.selectedRegion = event.detail.value;
-        this.fetchWatchlistData(); // Refresh data when region changes
-        setLastRegion({ componentName: COMPONENT_NAME, lastRegion: this.selectedRegion })
-            .catch(error => {
-                console.error('Error setting last region:', error);
-            });
-    }
+  regionOptions = [
+    { label: "Ontario", value: "Ontario" },
+    { label: "Alberta", value: "Alberta" },
+    { label: "Quebec", value: "Quebec" },
+    { label: "Atlantic", value: "Atlantic" },
+    { label: "Western", value: "Western" }
+  ];
 
-    handleLimitChange(event) {
-        this.selectedLimit = parseInt(event.detail.value);
-        this.fetchWatchlistData();
-    }
-    
-    handleComparisonToggle(event) {
-        this.comparisonType = event.target.checked ? 'YearOverYear' : 'MonthOverMonth';
-        this.fetchWatchlistData();
-    }
+  limitOptions = [
+    { label: "Top 5", value: 5 },
+    { label: "Top 10", value: 10 },
+    { label: "Top 15", value: 15 },
+    { label: "Top 25", value: 25 }
+  ];
 
-    async fetchWatchlistData() {
-        this.isLoading = true;
-        try {
-            const data = await getDealerWinnersLosers({ 
-                maxResults: this.selectedLimit,
-                comparisonType: this.comparisonType
-            });
-            this.watchlistData = this.processWinnersLosersData(data);
-        } catch (error) {
-            console.error('Error fetching winners/losers data:', error);
-        } finally {
-            this.isLoading = false;
+  // New getter for comparison type toggle
+  get isYearOverYear() {
+    return this.comparisonType === "YearOverYear";
+  }
+
+  get bannerSubtitle() {
+    const comparison = this.isYearOverYear
+      ? "YTD vs 2024 Comparison"
+      : "Month over Month Comparison";
+    return `Winners & Losers • Recreational Business Line • ${comparison}`;
+  }
+
+  get toggleLabel() {
+    return this.isYearOverYear ? "Year over Year" : "Month over Month";
+  }
+
+  async connectedCallback() {
+    // Load unified styles
+    await loadUnifiedStyles(this);
+
+    getLastRegion({ componentName: COMPONENT_NAME })
+      .then((result) => {
+        if (
+          result &&
+          this.regionOptions.some((option) => option.value === result)
+        ) {
+          this.selectedRegion = result;
+        } else {
+          this.selectedRegion = "Ontario";
         }
-    }
+        this.fetchWatchlistData();
+      })
+      .catch((error) => {
+        console.error("Error getting last region:", error);
+        this.selectedRegion = "Ontario";
+        this.fetchWatchlistData();
+      });
+  }
 
-    processWinnersLosersData(data) {
-        // Each region has: { region, winners: [DealerDelta], losers: [DealerDelta] }
-        return data.map(regionData => {
-            const processDealer = (dealer, index) => {
-                const deltaText = dealer.delta != null ? `$${dealer.delta.toLocaleString(undefined, {maximumFractionDigits: 0})}` : 'N/A';
-                const currentText = dealer.mtdAmount != null ? `$${dealer.mtdAmount.toLocaleString(undefined, {maximumFractionDigits: 0})}` : 'N/A';
-                const previousText = dealer.prevMonthAmount != null ? `$${dealer.prevMonthAmount.toLocaleString(undefined, {maximumFractionDigits: 0})}` : 'N/A';
-                const absDelta = dealer.delta != null ? Math.abs(dealer.delta) : 0;
-                const deltaClass = dealer.delta > 0 ? 'delta-positive' : (dealer.delta < 0 ? 'delta-negative' : '');
-                
-                return {
-                    ...dealer,
-                    rank: index + 1,
-                    deltaText,
-                    mtdText: currentText,
-                    prevText: previousText,
-                    absDelta,
-                    deltaClass
-                };
-            };
-            const winners = (regionData.winners || []).map(processDealer);
-            const losers = (regionData.losers || []).map(processDealer);
-            return {
-                name: regionData.region,
-                region: regionData.region,
-                winners,
-                losers,
-                hasWinners: winners.length > 0,
-                hasLosers: losers.length > 0
-            };
-        });
-    }
+  handleRegionChange(event) {
+    this.selectedRegion = event.detail.value;
+    this.fetchWatchlistData(); // Refresh data when region changes
+    setLastRegion({
+      componentName: COMPONENT_NAME,
+      lastRegion: this.selectedRegion
+    }).catch((error) => {
+      console.error("Error setting last region:", error);
+    });
+  }
 
-    // Getters for template data
-    get currentRegionData() {
-        return this.watchlistData.find(region => region.name === this.selectedRegion) || 
-               { winners: [], losers: [] };
-    }
+  handleLimitChange(event) {
+    this.selectedLimit = parseInt(event.detail.value, 10);
+    this.fetchWatchlistData();
+  }
 
-    get winners() {
-        return this.currentRegionData.winners || [];
-    }
+  handleComparisonToggle(event) {
+    this.comparisonType = event.target.checked
+      ? "YearOverYear"
+      : "MonthOverMonth";
+    this.fetchWatchlistData();
+  }
 
-    get losers() {
-        return this.currentRegionData.losers || [];
+  async fetchWatchlistData() {
+    this.isLoading = true;
+    try {
+      const data = await getDealerWinnersLosers({
+        maxResults: this.selectedLimit,
+        comparisonType: this.comparisonType
+      });
+      const processed = this.processWinnersLosersData(data);
+      await this.attachAccountLinks(processed);
+      this.watchlistData = processed;
+    } catch (error) {
+      console.error("Error fetching winners/losers data:", error);
+    } finally {
+      this.isLoading = false;
     }
+  }
 
-    get hasWinners() {
-        return this.winners.length > 0;
-    }
+  processWinnersLosersData(data) {
+    // Each region has: { region, winners: [DealerDelta], losers: [DealerDelta] }
+    return data.map((regionData) => {
+      const processDealer = (dealer, index) => {
+        const deltaText =
+          dealer.delta != null
+            ? `$${dealer.delta.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const currentText =
+          dealer.mtdAmount != null
+            ? `$${dealer.mtdAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const previousText =
+          dealer.prevMonthAmount != null
+            ? `$${dealer.prevMonthAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const absDelta = dealer.delta != null ? Math.abs(dealer.delta) : 0;
+        const deltaClass =
+          dealer.delta > 0
+            ? "delta-positive"
+            : dealer.delta < 0
+              ? "delta-negative"
+              : "";
 
-    get hasLosers() {
-        return this.losers.length > 0;
-    }
+        return {
+          ...dealer,
+          rank: index + 1,
+          deltaText,
+          mtdText: currentText,
+          prevText: previousText,
+          absDelta,
+          deltaClass
+        };
+      };
+      const winners = (regionData.winners || []).map(processDealer);
+      const losers = (regionData.losers || []).map(processDealer);
+      return {
+        name: regionData.region,
+        region: regionData.region,
+        winners,
+        losers,
+        hasWinners: winners.length > 0,
+        hasLosers: losers.length > 0
+      };
+    });
+  }
 
-    get winnersCount() {
-        return this.winners.length;
-    }
+  async attachAccountLinks(regionDataList) {
+    // Collect unique dealer names across all regions
+    const uniqueNames = new Set();
+    regionDataList.forEach((region) => {
+      region.winners.forEach((d) => uniqueNames.add(d.name));
+      region.losers.forEach((d) => uniqueNames.add(d.name));
+    });
 
-    get losersCount() {
-        return this.losers.length;
-    }
+    // Fetch account ids in parallel
+    const promises = Array.from(uniqueNames).map((name) =>
+      findAccountByDealerName({ dealerName: name })
+        .then((result) => ({
+          name,
+          accountId: result ? result.accountId : null
+        }))
+        .catch(() => ({ name, accountId: null }))
+    );
 
-    get currentPeriodLabel() {
-        return this.isYearOverYear ? 'YTD 2025' : 'Current Month';
-    }
+    const results = await Promise.all(promises);
+    const accountMap = new Map();
+    results.forEach((r) => accountMap.set(r.name, r.accountId));
 
-    get previousPeriodLabel() {
-        return this.isYearOverYear ? 'YTD 2024' : 'Previous Month';
-    }
+    // Attach URLs back to each dealer entry
+    regionDataList.forEach((region) => {
+      [...region.winners, ...region.losers].forEach((dealer) => {
+        const id = accountMap.get(dealer.name);
+        dealer.accountId = id;
+        dealer.accountUrl = id ? `/lightning/r/Account/${id}/view` : null;
+      });
+    });
+  }
 
-    get hasNoData() {
-        return !this.hasWinners && !this.hasLosers;
-    }
+  // Getters for template data
+  get currentRegionData() {
+    return (
+      this.watchlistData.find(
+        (region) => region.name === this.selectedRegion
+      ) || { winners: [], losers: [] }
+    );
+  }
+
+  get winners() {
+    return this.currentRegionData.winners || [];
+  }
+
+  get losers() {
+    return this.currentRegionData.losers || [];
+  }
+
+  get hasWinners() {
+    return this.winners.length > 0;
+  }
+
+  get hasLosers() {
+    return this.losers.length > 0;
+  }
+
+  get winnersCount() {
+    return this.winners.length;
+  }
+
+  get losersCount() {
+    return this.losers.length;
+  }
+
+  get currentPeriodLabel() {
+    return this.isYearOverYear ? "YTD 2025" : "Current Month";
+  }
+
+  get previousPeriodLabel() {
+    return this.isYearOverYear ? "YTD 2024" : "Previous Month";
+  }
+
+  get hasNoData() {
+    return !this.hasWinners && !this.hasLosers;
+  }
 }


### PR DESCRIPTION
## Summary
- link dealer names in watchlist directly to their Account records
- lookup Account IDs for winners and losers asynchronously

## Testing
- `npm test`
- `npm run lint` *(fails: Restricted async operation and other existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6894bbce4e848330aa3b538770d0b0ee