### PR TITLE
feat: link top dealers to account pages

### DIFF
--- a/BetaOne/force-app/main/default/lwc/topDealersCompact/topDealersCompact.html
+++ b/BetaOne/force-app/main/default/lwc/topDealersCompact/topDealersCompact.html
@@ -25,7 +25,14 @@
                     <template for:each={dealers} for:item="dealer">
                         <li key={dealer.rank} class="dealer-item">
                             <span class="dealer-rank">{dealer.rank}</span>
-                            <span class="dealer-name" title={dealer.Name}>{dealer.Name}</span>
+                            <span class="dealer-name" title={dealer.Name}>
+                                <template if:true={dealer.accountLink}>
+                                    <a href={dealer.accountLink} target="_blank" class="dealer-link-text">{dealer.Name}</a>
+                                </template>
+                                <template if:false={dealer.accountLink}>
+                                    {dealer.Name}
+                                </template>
+                            </span>
                             <span class="dealer-metric">{dealer.MetricFormatted}</span>
                         </li>
                     </template>


### PR DESCRIPTION
## Summary
- link top dealer names to Salesforce account pages
- dynamically fetch account IDs for dealers

## Testing
- `npm run lint` *(fails: ESLint couldn't find config; After installing deps, lint reports existing errors in unrelated files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bd8057348330aa332782965ece64