### PR TITLE
Fix invisible link text in Top Dealers component

### DIFF
--- a/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
+++ b/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
@@ -847,11 +847,11 @@ input {
    ============================================== */
 
 .dealer-link-text {
-    color: var(--primary-color);
+    color: var(--primary-color, #1b96ff);
 }
 
 .dealer-link-text:hover {
-    color: var(--secondary-color);
+    color: var(--secondary-color, #ffa41b);
 }
 
 /* ==============================================
@@ -1018,10 +1018,10 @@ input {
 
 /* Dealer link text */
 .dealer-link-text {
-    color: var(--primary-color);
+    color: var(--primary-color, #1b96ff);
 }
 .dealer-link-text:hover {
-    color: var(--secondary-color);
+    color: var(--secondary-color, #ffa41b);
 }
 
 /* Static resource viewer image */


### PR DESCRIPTION
## Summary
- add fallback link colors so top dealers hyperlinks remain visible even when theme variables are missing

## Testing
- `npm run lint` *(fails: 'setTimeout' restricted, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e52b6c9c8330b959788b0f4a1dd3