### PR TITLE
feat: add compact dealer watchlist component

### DIFF
--- a/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.css
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.css
@@ -1,0 +1,95 @@
+.watchlist-compact-container {
+    background: var(--card-background-color);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 4px var(--shadow-color);
+}
+
+.compact-header {
+    margin-bottom: 0.75rem;
+    text-align: center;
+}
+
+.compact-title {
+    color: var(--brand-primary);
+    margin: 0;
+    font-size: var(--text-xl);
+    font-weight: var(--font-weight-semibold);
+}
+
+.compact-subtitle {
+    color: var(--text-muted);
+    margin: 0;
+    font-size: var(--text-sm);
+}
+
+.controls-row {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-bottom: 0.75rem;
+}
+
+.lists-grid {
+    display: flex;
+    gap: 1rem;
+}
+
+.list-section {
+    flex: 1;
+    background: var(--secondary-background);
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+}
+
+.section-header {
+    font-weight: var(--font-weight-semibold);
+    color: var(--brand-secondary);
+    margin-bottom: 0.5rem;
+}
+
+.dealer-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.dealer-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.dealer-row:last-child {
+    border-bottom: none;
+}
+
+.rank {
+    width: 1.5rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--brand-secondary);
+}
+
+.name {
+    flex: 1;
+    margin-left: 0.25rem;
+}
+
+.delta {
+    font-weight: var(--font-weight-semibold);
+}
+
+.delta-positive {
+    color: var(--success-color);
+}
+
+.delta-negative {
+    color: var(--error-color);
+}
+
+.no-data-message {
+    text-align: center;
+    color: var(--text-muted);
+}

--- a/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.html
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.html
@@ -1,0 +1,87 @@
+<template>
+    <div class="watchlist-compact-container app-container">
+        <div class="compact-header">
+            <h3 class="compact-title">Dealer Watchlist</h3>
+            <p class="compact-subtitle">{bannerSubtitle}</p>
+        </div>
+        <div class="controls-row">
+            <lightning-combobox
+                name="region"
+                label="Region"
+                value={selectedRegion}
+                options={regionOptions}
+                onchange={handleRegionChange}
+                class="region-combobox"
+                variant="label-hidden">
+            </lightning-combobox>
+            <lightning-combobox
+                name="limit"
+                label="Results"
+                value={selectedLimit}
+                options={limitOptions}
+                onchange={handleLimitChange}
+                class="limit-combobox"
+                variant="label-hidden">
+            </lightning-combobox>
+            <lightning-input
+                type="toggle"
+                label={toggleLabel}
+                checked={isYearOverYear}
+                onchange={handleComparisonToggle}
+                class="comparison-toggle">
+            </lightning-input>
+        </div>
+        <template if:true={isLoading}>
+            <div class="loading-container">
+                <lightning-spinner alternative-text="Loading dealer data..." size="small"></lightning-spinner>
+            </div>
+        </template>
+        <template if:false={isLoading}>
+            <template if:true={hasNoData}>
+                <div class="no-data-message">No dealer data available.</div>
+            </template>
+            <template if:false={hasNoData}>
+                <div class="lists-grid">
+                    <div class="list-section winners">
+                        <div class="section-header">Top Performers ({winnersCount})</div>
+                        <ul class="dealer-list">
+                            <template for:each={winners} for:item="dealer">
+                                <li key={dealer.name} class="dealer-row">
+                                    <span class="rank">{dealer.rank}</span>
+                                    <span class="name">
+                                        <template if:true={dealer.accountUrl}>
+                                            <a href={dealer.accountUrl} target="_blank" class="dealer-link-text">{dealer.name}</a>
+                                        </template>
+                                        <template if:false={dealer.accountUrl}>
+                                            {dealer.name}
+                                        </template>
+                                    </span>
+                                    <span class="delta {dealer.deltaClass}">{dealer.deltaText}</span>
+                                </li>
+                            </template>
+                        </ul>
+                    </div>
+                    <div class="list-section losers">
+                        <div class="section-header">Underperformers ({losersCount})</div>
+                        <ul class="dealer-list">
+                            <template for:each={losers} for:item="dealer">
+                                <li key={dealer.name} class="dealer-row">
+                                    <span class="rank">{dealer.rank}</span>
+                                    <span class="name">
+                                        <template if:true={dealer.accountUrl}>
+                                            <a href={dealer.accountUrl} target="_blank" class="dealer-link-text">{dealer.name}</a>
+                                        </template>
+                                        <template if:false={dealer.accountUrl}>
+                                            {dealer.name}
+                                        </template>
+                                    </span>
+                                    <span class="delta {dealer.deltaClass}">{dealer.deltaText}</span>
+                                </li>
+                            </template>
+                        </ul>
+                    </div>
+                </div>
+            </template>
+        </template>
+    </div>
+</template>

--- a/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.js
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.js
@@ -1,0 +1,235 @@
+// Dealer Watchlist component handles UI logic and data interactions
+import { LightningElement, track } from "lwc";
+import getDealerWinnersLosers from "@salesforce/apex/DealerWatchlistController.getDealerWinnersLosers";
+import findAccountByDealerName from "@salesforce/apex/TopDealersController.findAccountByDealerName";
+import getLastRegion from "@salesforce/apex/UserComponentPreferenceService.getLastRegion";
+import setLastRegion from "@salesforce/apex/UserComponentPreferenceService.setLastRegion";
+import { loadUnifiedStyles } from "c/unifiedStylesHelper";
+
+const COMPONENT_NAME = "dealerWatchlistCompact";
+
+export default class DealerWatchlistCompact extends LightningElement {
+  @track watchlistData = [];
+  @track isLoading = false;
+  @track selectedRegion = "Ontario";
+  @track selectedLimit = 10;
+  @track comparisonType = "MonthOverMonth"; // New property for comparison type
+
+  regionOptions = [
+    { label: "Ontario", value: "Ontario" },
+    { label: "Alberta", value: "Alberta" },
+    { label: "Quebec", value: "Quebec" },
+    { label: "Atlantic", value: "Atlantic" },
+    { label: "Western", value: "Western" }
+  ];
+
+  limitOptions = [
+    { label: "Top 5", value: 5 },
+    { label: "Top 10", value: 10 },
+    { label: "Top 15", value: 15 },
+    { label: "Top 25", value: 25 }
+  ];
+
+  // New getter for comparison type toggle
+  get isYearOverYear() {
+    return this.comparisonType === "YearOverYear";
+  }
+
+  get bannerSubtitle() {
+    const comparison = this.isYearOverYear
+      ? "YTD vs 2024 Comparison"
+      : "Month over Month Comparison";
+    return `Winners & Losers • Recreational Business Line • ${comparison}`;
+  }
+
+  get toggleLabel() {
+    return this.isYearOverYear ? "Year over Year" : "Month over Month";
+  }
+
+  async connectedCallback() {
+    // Load unified styles
+    await loadUnifiedStyles(this);
+
+    getLastRegion({ componentName: COMPONENT_NAME })
+      .then((result) => {
+        if (
+          result &&
+          this.regionOptions.some((option) => option.value === result)
+        ) {
+          this.selectedRegion = result;
+        } else {
+          this.selectedRegion = "Ontario";
+        }
+        this.fetchWatchlistData();
+      })
+      .catch((error) => {
+        console.error("Error getting last region:", error);
+        this.selectedRegion = "Ontario";
+        this.fetchWatchlistData();
+      });
+  }
+
+  handleRegionChange(event) {
+    this.selectedRegion = event.detail.value;
+    this.fetchWatchlistData(); // Refresh data when region changes
+    setLastRegion({
+      componentName: COMPONENT_NAME,
+      lastRegion: this.selectedRegion
+    }).catch((error) => {
+      console.error("Error setting last region:", error);
+    });
+  }
+
+  handleLimitChange(event) {
+    this.selectedLimit = parseInt(event.detail.value, 10);
+    this.fetchWatchlistData();
+  }
+
+  handleComparisonToggle(event) {
+    this.comparisonType = event.target.checked
+      ? "YearOverYear"
+      : "MonthOverMonth";
+    this.fetchWatchlistData();
+  }
+
+  async fetchWatchlistData() {
+    this.isLoading = true;
+    try {
+      const data = await getDealerWinnersLosers({
+        maxResults: this.selectedLimit,
+        comparisonType: this.comparisonType
+      });
+      const processed = this.processWinnersLosersData(data);
+      await this.attachAccountLinks(processed);
+      this.watchlistData = processed;
+    } catch (error) {
+      console.error("Error fetching winners/losers data:", error);
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  processWinnersLosersData(data) {
+    // Each region has: { region, winners: [DealerDelta], losers: [DealerDelta] }
+    return data.map((regionData) => {
+      const processDealer = (dealer, index) => {
+        const deltaText =
+          dealer.delta != null
+            ? `$${dealer.delta.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const currentText =
+          dealer.mtdAmount != null
+            ? `$${dealer.mtdAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const previousText =
+          dealer.prevMonthAmount != null
+            ? `$${dealer.prevMonthAmount.toLocaleString(undefined, { maximumFractionDigits: 0 })}`
+            : "N/A";
+        const absDelta = dealer.delta != null ? Math.abs(dealer.delta) : 0;
+        const deltaClass =
+          dealer.delta > 0
+            ? "delta-positive"
+            : dealer.delta < 0
+              ? "delta-negative"
+              : "";
+
+        return {
+          ...dealer,
+          rank: index + 1,
+          deltaText,
+          mtdText: currentText,
+          prevText: previousText,
+          absDelta,
+          deltaClass
+        };
+      };
+      const winners = (regionData.winners || []).map(processDealer);
+      const losers = (regionData.losers || []).map(processDealer);
+      return {
+        name: regionData.region,
+        region: regionData.region,
+        winners,
+        losers,
+        hasWinners: winners.length > 0,
+        hasLosers: losers.length > 0
+      };
+    });
+  }
+
+  async attachAccountLinks(regionDataList) {
+    // Collect unique dealer names across all regions
+    const uniqueNames = new Set();
+    regionDataList.forEach((region) => {
+      region.winners.forEach((d) => uniqueNames.add(d.name));
+      region.losers.forEach((d) => uniqueNames.add(d.name));
+    });
+
+    // Fetch account ids in parallel
+    const promises = Array.from(uniqueNames).map((name) =>
+      findAccountByDealerName({ dealerName: name })
+        .then((result) => ({
+          name,
+          accountId: result ? result.accountId : null
+        }))
+        .catch(() => ({ name, accountId: null }))
+    );
+
+    const results = await Promise.all(promises);
+    const accountMap = new Map();
+    results.forEach((r) => accountMap.set(r.name, r.accountId));
+
+    // Attach URLs back to each dealer entry
+    regionDataList.forEach((region) => {
+      [...region.winners, ...region.losers].forEach((dealer) => {
+        const id = accountMap.get(dealer.name);
+        dealer.accountId = id;
+        dealer.accountUrl = id ? `/lightning/r/Account/${id}/view` : null;
+      });
+    });
+  }
+
+  // Getters for template data
+  get currentRegionData() {
+    return (
+      this.watchlistData.find(
+        (region) => region.name === this.selectedRegion
+      ) || { winners: [], losers: [] }
+    );
+  }
+
+  get winners() {
+    return this.currentRegionData.winners || [];
+  }
+
+  get losers() {
+    return this.currentRegionData.losers || [];
+  }
+
+  get hasWinners() {
+    return this.winners.length > 0;
+  }
+
+  get hasLosers() {
+    return this.losers.length > 0;
+  }
+
+  get winnersCount() {
+    return this.winners.length;
+  }
+
+  get losersCount() {
+    return this.losers.length;
+  }
+
+  get currentPeriodLabel() {
+    return this.isYearOverYear ? "YTD 2025" : "Current Month";
+  }
+
+  get previousPeriodLabel() {
+    return this.isYearOverYear ? "YTD 2024" : "Previous Month";
+  }
+
+  get hasNoData() {
+    return !this.hasWinners && !this.hasLosers;
+  }
+}

--- a/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.js-meta.xml
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlistCompact/dealerWatchlistCompact.js-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add new dealerWatchlistCompact component for A/B testing with compact layout
- apply brand color tokens for more vibrant watchlist styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e5717e28833088e05d413694e62c