### PR TITLE
Display volume and month on monthly goal chart

### DIFF
--- a/BetaOne/force-app/main/default/classes/SalesDataService.cls
+++ b/BetaOne/force-app/main/default/classes/SalesDataService.cls
@@ -23,12 +23,14 @@ public with sharing class SalesDataService {
         ];
 
         Map<Integer, Decimal> cumulativeData = new Map<Integer, Decimal>();
+        Map<Integer, Decimal> volumeData = new Map<Integer, Decimal>();
         Decimal cumulativeTotal = 0;
         for (AggregateResult ar : results) {
             Integer day = (Integer) ar.get('day');
             Decimal total = (Decimal) ar.get('total');
             cumulativeTotal += total;
             cumulativeData.put(day, cumulativeTotal);
+            volumeData.put(day, total);
         }
 
         Decimal monthlyGoal = 0;
@@ -56,6 +58,7 @@ public with sharing class SalesDataService {
 
         Map<String, Object> data = new Map<String, Object>();
         data.put('cumulativeData', cumulativeData);
+        data.put('volumeData', volumeData);
         data.put('monthlyGoal', monthlyGoal);
 
         return data;

--- a/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
+++ b/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
@@ -56,13 +56,16 @@ private class SalesDataServiceTest {
         Test.stopTest();
 
         Map<Integer, Decimal> cumulativeData = (Map<Integer, Decimal>)result.get('cumulativeData');
+        Map<Integer, Decimal> volumeData = (Map<Integer, Decimal>)result.get('volumeData');
         Decimal monthlyGoal = (Decimal)result.get('monthlyGoal');
-        
+
         System.assertNotEquals(null, cumulativeData, 'Cumulative data should not be null');
+        System.assertNotEquals(null, volumeData, 'Volume data should not be null');
         System.assertNotEquals(null, monthlyGoal, 'Monthly goal should not be null');
-        
+
         // Check that cumulative data includes Ontario records
         System.assert(cumulativeData.size() > 0, 'Should have cumulative data for Ontario');
+        System.assert(volumeData.size() > 0, 'Should have volume data for Ontario');
     }
 
     @isTest
@@ -143,11 +146,14 @@ private class SalesDataServiceTest {
         Test.stopTest();
 
         Map<Integer, Decimal> cumulativeData = (Map<Integer, Decimal>)result.get('cumulativeData');
+        Map<Integer, Decimal> volumeData = (Map<Integer, Decimal>)result.get('volumeData');
         Decimal monthlyGoal = (Decimal)result.get('monthlyGoal');
-        
+
         System.assertNotEquals(null, cumulativeData, 'Cumulative data should not be null');
+        System.assertNotEquals(null, volumeData, 'Volume data should not be null');
         System.assertEquals(0, monthlyGoal, 'Unknown region should have 0 monthly goal');
         System.assertEquals(0, cumulativeData.size(), 'Unknown region should have no cumulative data');
+        System.assertEquals(0, volumeData.size(), 'Unknown region should have no volume data');
     }
 
     @isTest

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.html
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.html
@@ -1,5 +1,5 @@
 <template>
-  <lightning-card title="Monthly Goal">
+  <lightning-card title={cardTitle}>
     <div class="slds-p-around_medium">
       <template if:true={regionOptions}>
         <lightning-combobox

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
@@ -8,6 +8,9 @@ export default class MonthlyGoalChart extends LightningElement {
   @track regionOptions = [];
   @track selectedRegion;
   @track isLoading = true;
+  @track cardTitle = `Monthly Goal - ${new Date().toLocaleString("en-US", {
+    month: "long"
+  })}`;
   chart;
   chartJsInitialized = false;
 
@@ -38,6 +41,13 @@ export default class MonthlyGoalChart extends LightningElement {
           data: {
             labels: [],
             datasets: [
+              {
+                label: "Volume",
+                data: [],
+                type: "bar",
+                backgroundColor: "#90caf9",
+                borderColor: "#90caf9"
+              },
               {
                 label: "Cumulative",
                 data: [],
@@ -95,6 +105,7 @@ export default class MonthlyGoalChart extends LightningElement {
     this.isLoading = true;
     getSalesData({ region: this.selectedRegion })
       .then((result) => {
+        const volume = result.volumeData || {};
         const cumulative = result.cumulativeData || {};
         const goal = result.monthlyGoal || 0;
         const now = new Date();
@@ -104,10 +115,12 @@ export default class MonthlyGoalChart extends LightningElement {
           0
         ).getDate();
         const labels = Array.from({ length: daysInMonth }, (_, i) => i + 1);
+        const volumeData = labels.map((day) => volume[day] || 0);
         const cumulativeData = labels.map((day) => cumulative[day] || null);
         this.chart.data.labels = labels;
-        this.chart.data.datasets[0].data = cumulativeData;
-        this.chart.data.datasets[1].data = Array(daysInMonth).fill(goal);
+        this.chart.data.datasets[0].data = volumeData;
+        this.chart.data.datasets[1].data = cumulativeData;
+        this.chart.data.datasets[2].data = Array(daysInMonth).fill(goal);
         this.chart.update();
       })
       .catch((error) => {


### PR DESCRIPTION
## Summary
- extend `SalesDataService` to return daily volume data
- show daily volume and current month in monthly goal chart
- cover volume data in `SalesDataServiceTest`

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6894ef0fc6688330a2bbbc5a864db6e9