### PR TITLE
feat: round corners for quickpdfs app

### DIFF
--- a/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
+++ b/BetaOne/force-app/main/default/staticresources/unifiedStyles.css
@@ -860,7 +860,7 @@ input {
 
 .pdf-container {
     background: var(--card-background-color);
-    border-radius: var(--border-radius);
+    border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-md);
     overflow: hidden;
     min-height: 300px;


### PR DESCRIPTION
## Summary
- increase border radius on Quick PDFs container for a rounded appearance

## Testing
- `npm test`
- `npm run lint` *(fails: Restricted async operation "setTimeout", 'index' is defined but never used, 'ticks' is defined but never used, Expected '===' and instead saw '==', Do not access Object.prototype method 'hasOwnProperty' from target object, Restricted async operation "setInterval", Unnecessary 'else' after 'return')*


------
https://chatgpt.com/codex/tasks/task_e_6894f5470fbc83308c6545170beb870c