### PR TITLE
feat: add timescale control and summary grid

### DIFF
--- a/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.css
+++ b/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.css
@@ -1,3 +1,32 @@
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.summary-item {
+    background: var(--lwc-colorBackgroundAlt, #f3f3f3);
+    padding: 0.75rem;
+    border-radius: 0.25rem;
+    text-align: center;
+}
+
+.summary-label {
+    font-size: 0.75rem;
+    color: var(--lwc-colorTextWeak, #666);
+    margin-bottom: 0.25rem;
+}
+
+.summary-value {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.controls {
+    margin-bottom: 1rem;
+}
+
 .chart-container {
     height: 300px;
 }

--- a/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.html
+++ b/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.html
@@ -11,13 +11,29 @@
         </div>
         <template if:true={selectedDealer}>
             <div class="slds-p-around_medium">
-                <p class="slds-text-heading_small">
-                    {selectedDealer.dealerName} - {selectedDealer.region}
-                </p>
-                <p>Total Deals: {selectedDealer.totalDeals}</p>
-                <p>
-                    Total Financed: {formattedTotalFinanced}
-                </p>
+                <div class="summary-grid">
+                    <div class="summary-item">
+                        <p class="summary-label">Dealer</p>
+                        <p class="summary-value">{selectedDealer.dealerName} - {selectedDealer.region}</p>
+                    </div>
+                    <div class="summary-item">
+                        <p class="summary-label">Total Deals</p>
+                        <p class="summary-value">{selectedDealer.totalDeals}</p>
+                    </div>
+                    <div class="summary-item">
+                        <p class="summary-label">Total Financed</p>
+                        <p class="summary-value">{formattedTotalFinanced}</p>
+                    </div>
+                </div>
+                <div class="controls">
+                    <lightning-combobox
+                        name="timescale"
+                        label="Timescale"
+                        value={selectedMonths}
+                        options={timescaleOptions}
+                        onchange={handleTimescaleChange}
+                    ></lightning-combobox>
+                </div>
                 <div class="chart-container">
                     <canvas class="chart-canvas"></canvas>
                 </div>

--- a/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.js
+++ b/BetaOne/force-app/main/default/lwc/dealerDetailApp/dealerDetailApp.js
@@ -9,6 +9,13 @@ export default class DealerDetailApp extends LightningElement {
     @track dealerOptions = [];
     selectedDealerId = '';
     @track selectedDealer;
+    selectedMonths = '12';
+    timescaleOptions = [
+        { label: '3 Months', value: '3' },
+        { label: '6 Months', value: '6' },
+        { label: '12 Months', value: '12' },
+        { label: '24 Months', value: '24' }
+    ];
     chart;
     chartJsInitialized = false;
 
@@ -48,18 +55,34 @@ export default class DealerDetailApp extends LightningElement {
         getDealerDetails({ dealerId: this.selectedDealerId })
             .then((result) => {
                 this.selectedDealer = result;
-                return getDealerChartDataWithPeriod({
-                    dealerId: this.selectedDealerId,
-                    monthsBack: 12
-                });
-            })
-            .then((chartData) => {
-                this.renderChart(chartData);
+                return this.loadChartData();
             })
             .catch((error) => {
                 // eslint-disable-next-line no-console
                 console.error('Error loading dealer details', error);
                 this.selectedDealer = undefined;
+            });
+    }
+
+    handleTimescaleChange(event) {
+        this.selectedMonths = event.detail.value;
+        this.loadChartData();
+    }
+
+    loadChartData() {
+        if (!this.selectedDealerId) {
+            return Promise.resolve();
+        }
+        return getDealerChartDataWithPeriod({
+            dealerId: this.selectedDealerId,
+            monthsBack: parseInt(this.selectedMonths, 10)
+        })
+            .then((chartData) => {
+                this.renderChart(chartData);
+            })
+            .catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error('Error loading chart data', error);
             });
     }
 


### PR DESCRIPTION
## Summary
- style summary stats using responsive grid layout
- allow adjusting graph timescale via dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f624ae2c833091bc057aca98f9ff