### PR TITLE
Add national option to monthly goal chart and refine region mapping

### DIFF
--- a/BetaOne/README.md
+++ b/BetaOne/README.md
@@ -13,7 +13,7 @@ This release introduces a comprehensive suite of Lightning Web Components (LWC) 
 
 ##### **1. Top Dealers Component (`topDealers`)**
 - Regional dealer performance tracking with dynamic data visualization
-- Real-time filtering by region (Ontario, Alberta, Eastern, Western)
+ - Real-time filtering by region (National, Ontario, Alberta, Quebec, Atlantic, Western)
 - Integration with Account records for seamless navigation
 - User preference persistence for region selection
 - Rolling 120-day performance metrics
@@ -89,7 +89,7 @@ This release introduces a comprehensive suite of Lightning Web Components (LWC) 
 
 ### 📊 Key Metrics & Features
 - **Rolling Period Analysis**: 120-day rolling window for performance tracking
-- **Regional Support**: Ontario, Alberta, Eastern, Western regions
+- **Regional Support**: National, Ontario, Alberta, Quebec, Atlantic, Western regions
 - **Year-over-Year Comparisons**: Historical performance analysis
 - **Real-time Data**: Live data updates and synchronization
 - **User Preferences**: Persistent component state across sessions

--- a/BetaOne/force-app/main/default/classes/SalesDataService.cls
+++ b/BetaOne/force-app/main/default/classes/SalesDataService.cls
@@ -43,7 +43,14 @@ public with sharing class SalesDataService {
         if (!goals.isEmpty() && region != null) {
             Monthly_Goal__c firstGoal = goals[0];
             String regionLower = region != null ? region.toLowerCase() : '';
-            if (regionLower.contains('alberta')) {
+            if (regionLower.contains('national')) {
+                monthlyGoal =
+                    (firstGoal.Region_Target_Alberta__c != null ? firstGoal.Region_Target_Alberta__c : 0) +
+                    (firstGoal.Region_Target_Quebec__c != null ? firstGoal.Region_Target_Quebec__c : 0) +
+                    (firstGoal.Region_Target_Eastern__c != null ? firstGoal.Region_Target_Eastern__c : 0) +
+                    (firstGoal.Region_Target_Ontario__c != null ? firstGoal.Region_Target_Ontario__c : 0) +
+                    (firstGoal.Region_Target_Western__c != null ? firstGoal.Region_Target_Western__c : 0);
+            } else if (regionLower.contains('alberta')) {
                 monthlyGoal = firstGoal.Region_Target_Alberta__c;
             } else if (regionLower.contains('quebec')) {
                 monthlyGoal = firstGoal.Region_Target_Quebec__c;
@@ -67,29 +74,33 @@ public with sharing class SalesDataService {
     @AuraEnabled(cacheable=true)
     public static List<String> getRegions() {
         return new List<String>{
+            'National',
             'Ontario',
-            'Alberta', 
+            'Alberta',
             'Quebec',
             'Atlantic',
             'Western'
         };
     }
-    
+
     private static Set<String> getProvincesForRegion(String region) {
         Set<String> provinces = new Set<String>();
-        
-        if (region == 'Ontario') {
+        String regionLower = region != null ? region.toLowerCase() : '';
+
+        if (regionLower == 'national') {
+            provinces.addAll(new Set<String>{'ON','AB','QC','NB','NS','PE','NL','BC','SK','MB'});
+        } else if (regionLower == 'ontario') {
             provinces.add('ON');
-        } else if (region == 'Alberta') {
+        } else if (regionLower == 'alberta') {
             provinces.add('AB');
-        } else if (region == 'Quebec') {
+        } else if (regionLower == 'quebec') {
             provinces.add('QC');
-        } else if (region == 'Atlantic') {
+        } else if (regionLower == 'atlantic') {
             provinces.addAll(new Set<String>{'NB', 'NS', 'PE', 'NL'});
-        } else if (region == 'Western') {
+        } else if (regionLower == 'western' || regionLower == 'british columbia' || regionLower == 'saskatchewan' || regionLower == 'manitoba') {
             provinces.addAll(new Set<String>{'BC', 'SK', 'MB'});
         }
-        
+
         return provinces;
     }
 }

--- a/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
+++ b/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
@@ -45,8 +45,17 @@ private class SalesDataServiceTest {
             Applications_Last_Amount_To_Finance_Sum__c = 800,
             Applications_Dealer_Province__c = 'NB'
         )        );
-        
+
         insert records;
+
+        Monthly_Goal__c goal = new Monthly_Goal__c(
+            Region_Target_Alberta__c = 1000,
+            Region_Target_Quebec__c = 2000,
+            Region_Target_Eastern__c = 3000,
+            Region_Target_Ontario__c = 4000,
+            Region_Target_Western__c = 5000
+        );
+        insert goal;
     }
 
     @isTest
@@ -112,6 +121,16 @@ private class SalesDataServiceTest {
     }
 
     @isTest
+    static void testGetSalesDataNational() {
+        Test.startTest();
+        Map<String, Object> result = SalesDataService.getSalesData('National');
+        Test.stopTest();
+
+        Decimal monthlyGoal = (Decimal)result.get('monthlyGoal');
+        System.assertEquals(1000 + 2000 + 3000 + 4000 + 5000, monthlyGoal, 'National goal should sum all regions');
+    }
+
+    @isTest
     static void testGetSalesDataBritishColumbia() {
         Test.startTest();
         Map<String, Object> result = SalesDataService.getSalesData('British Columbia');
@@ -173,7 +192,8 @@ private class SalesDataServiceTest {
         Test.stopTest();
 
         System.assertNotEquals(null, regions, 'Regions should not be null');
-        System.assertEquals(5, regions.size(), 'Should return 5 regions');
+        System.assertEquals(6, regions.size(), 'Should return 6 regions');
+        System.assert(regions.contains('National'), 'Should contain National');
         System.assert(regions.contains('Ontario'), 'Should contain Ontario');
         System.assert(regions.contains('Alberta'), 'Should contain Alberta');
         System.assert(regions.contains('Quebec'), 'Should contain Quebec');

--- a/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
+++ b/BetaOne/force-app/main/default/lwc/monthlyGoalChart/monthlyGoalChart.js
@@ -17,7 +17,10 @@ export default class MonthlyGoalChart extends LightningElement {
   @wire(getRegions)
   wiredRegions({ error, data }) {
     if (data) {
-      this.regionOptions = data.map((r) => ({ label: r, value: r }));
+      this.regionOptions = [
+        { label: "National", value: "National" },
+        ...data.map((r) => ({ label: r, value: r }))
+      ];
       this.selectedRegion = this.regionOptions[0]?.value;
     } else if (error) {
       // eslint-disable-next-line no-console
@@ -117,8 +120,12 @@ export default class MonthlyGoalChart extends LightningElement {
           return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
         });
         let runningTotal = 0;
+        const today = now.getDate();
         const cumulativeData = Array.from({ length: daysInMonth }, (_, i) => {
           const day = i + 1;
+          if (day > today) {
+            return null;
+          }
           runningTotal += volume[day] || 0;
           return runningTotal;
         });


### PR DESCRIPTION
## Summary
- Support a new **National** selection in Monthly Goal Chart and cap cumulative series at today's date
- Extend `SalesDataService` to aggregate national goals and handle case-insensitive region lookup
- Add coverage for national region and update README documentation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f9cf7d088330b18eb0bf342e4693