### PR TITLE
Add shared info banner and fix call goal layout

### DIFF
--- a/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.css
+++ b/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.css
@@ -9,8 +9,7 @@
     display: flex;
     flex-direction: column;
 }
-
-lightning-card {
+.content-section {
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.html
+++ b/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.html
@@ -1,7 +1,24 @@
 <template>
 
     <div class="container app-container">
-        <lightning-card title="Daily Call Goal">
+        <div class="header-section">
+            <div class="header-content">
+                <div class="title-group">
+                    <div class="header-icon">
+                        <lightning-icon icon-name="utility:call" size="medium"></lightning-icon>
+                    </div>
+                    <h2 class="main-title">Daily Call Goal</h2>
+                </div>
+            </div>
+            <div class="info-banner">
+                <div class="info-icon">
+                    <lightning-icon icon-name="utility:info" size="x-small"></lightning-icon>
+                </div>
+                <p class="info-text">Monitor daily calls against your goal</p>
+            </div>
+        </div>
+
+        <div class="content-section">
             <div class="metric-header slds-m-bottom_large">
                 <!-- Salesperson Dropdown -->
                 <template if:true={selectedSalespersonData}>
@@ -16,29 +33,29 @@
                     </lightning-combobox>
                 </template>
             </div>
-        
-        <!-- Loading State -->
-        <template if:true={isLoading}>
-            <div class="slds-text-align_center slds-p-around_x-large">
-                <lightning-spinner size="medium"></lightning-spinner>
-                <p class="slds-text-color_weak slds-m-top_small">Loading activity data...</p>
-            </div>
-        </template>
 
-        <!-- Error State -->
-        <template if:true={error}>
-            <div class="status-error slds-m-bottom_medium">
-                <lightning-icon icon-name="utility:error" size="small" class="slds-m-right_x-small"></lightning-icon>
-                {error}
-            </div>
-        </template>
+            <!-- Loading State -->
+            <template if:true={isLoading}>
+                <div class="slds-text-align_center slds-p-around_x-large">
+                    <lightning-spinner size="medium"></lightning-spinner>
+                    <p class="slds-text-color_weak slds-m-top_small">Loading activity data...</p>
+                </div>
+            </template>
 
-        <!-- Main Display -->
-        <template if:true={selectedSalespersonData}>
-            <!-- Donut Chart -->
-            <div class="chart-wrapper slds-text-align_center">
-                <div style="position: relative; display: inline-block; max-width: 300px; margin: 0 auto;">
-                    <svg viewBox="0 0 120 120" class="chart-svg" style="width: 100%; height: auto;">
+            <!-- Error State -->
+            <template if:true={error}>
+                <div class="status-error slds-m-bottom_medium">
+                    <lightning-icon icon-name="utility:error" size="small" class="slds-m-right_x-small"></lightning-icon>
+                    {error}
+                </div>
+            </template>
+
+            <!-- Main Display -->
+            <template if:true={selectedSalespersonData}>
+                <!-- Donut Chart -->
+                <div class="chart-wrapper slds-text-align_center">
+                    <div style="position: relative; display: inline-block; max-width: 300px; margin: 0 auto;">
+                        <svg viewBox="0 0 120 120" class="chart-svg" style="width: 100%; height: auto;">
                         <defs>
                             <!-- Circular gradient that follows the arc -->
                             <linearGradient id="progressGradient" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -128,6 +145,6 @@
                 </template>
             </template>
         </template>
-        </lightning-card>
+        </div>
     </div>
 </template>

--- a/BetaOne/force-app/main/default/lwc/dealerDetail/dealerDetail.html
+++ b/BetaOne/force-app/main/default/lwc/dealerDetail/dealerDetail.html
@@ -1,7 +1,24 @@
 <template>
     <!-- Modern Dealer Analytics Component -->
     <div class="dealer-analytics-container">
+        <div class="header-section">
+            <div class="header-content">
+                <div class="title-group">
+                    <div class="header-icon">
+                        <lightning-icon icon-name="standard:account" size="medium"></lightning-icon>
+                    </div>
+                    <h2 class="main-title">Dealer Detail</h2>
+                </div>
+            </div>
+            <div class="info-banner">
+                <div class="info-icon">
+                    <lightning-icon icon-name="utility:info" size="x-small"></lightning-icon>
+                </div>
+                <p class="info-text">Search and analyze dealer performance metrics</p>
+            </div>
+        </div>
 
+        <div class="content-section">
         <!-- Loading State -->
         <template if:true={isLoading}>
             <div class="loading-container">
@@ -198,5 +215,6 @@
 
             </div>
         </template>
+        </div>
     </div>
 </template>

--- a/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.html
+++ b/BetaOne/force-app/main/default/lwc/dealerWatchlist/dealerWatchlist.html
@@ -10,6 +10,12 @@
           </div>
         </div>
       </div>
+      <div class="info-banner">
+        <div class="info-icon">
+          <lightning-icon icon-name="utility:info" size="x-small"></lightning-icon>
+        </div>
+        <p class="info-text">Track performance metrics for key dealers</p>
+      </div>
     </div>
 
     <!-- Controls Section -->

--- a/BetaOne/force-app/main/default/lwc/topDealersCompact/topDealersCompact.html
+++ b/BetaOne/force-app/main/default/lwc/topDealersCompact/topDealersCompact.html
@@ -1,46 +1,64 @@
 <template>
     <div class="top-dealers-compact-container app-container">
-        <div class="compact-header">
-            <h3 class="compact-title">Top 5 Largest Dealers</h3>
-        </div>
-        <div class="region-selector-row">
-            <lightning-combobox
-                name="region"
-                label="Region"
-                value={region}
-                options={regionOptions}
-                onchange={handleRegionChange}
-                class="region-combobox"
-                variant="label-hidden">
-            </lightning-combobox>
-        </div>
-        <template if:true={dealers}>
-            <div class="dealers-table-wrapper">
-                <div class="dealers-table-header">
-                    <span class="header-rank">#</span>
-                    <span class="header-name">Dealer Name</span>
-                    <span class="header-metric">Amount Financed (MTD)</span>
+        <div class="header-section">
+            <div class="header-content">
+                <div class="title-group">
+                    <div class="header-icon">
+                        <lightning-icon icon-name="standard:account" size="medium"></lightning-icon>
+                    </div>
+                    <h2 class="main-title">Top 5 Largest Dealers</h2>
                 </div>
-                <ul class="dealers-list">
-                    <template for:each={dealers} for:item="dealer">
-                        <li key={dealer.rank} class="dealer-item">
-                            <span class="dealer-rank">{dealer.rank}</span>
-                            <span class="dealer-name" title={dealer.Name}>
-                                <template if:true={dealer.accountLink}>
-                                    <a href={dealer.accountLink} target="_blank" class="dealer-link-text">{dealer.Name}</a>
-                                </template>
-                                <template if:false={dealer.accountLink}>
-                                    {dealer.Name}
-                                </template>
-                            </span>
-                            <span class="dealer-metric">{dealer.MetricFormatted}</span>
-                        </li>
-                    </template>
-                </ul>
             </div>
-        </template>
-        <template if:false={dealers}>
-            <div class="no-data-message">No dealer data available.</div>
-        </template>
+            <div class="info-banner">
+                <div class="info-icon">
+                    <lightning-icon icon-name="utility:info" size="x-small"></lightning-icon>
+                </div>
+                <p class="info-text">View leading dealers by amount financed</p>
+            </div>
+        </div>
+
+        <div class="content-section">
+            <div class="controls-section">
+                <lightning-combobox
+                    name="region"
+                    label="Region"
+                    value={region}
+                    options={regionOptions}
+                    onchange={handleRegionChange}
+                    class="region-combobox"
+                    variant="label-hidden">
+                </lightning-combobox>
+            </div>
+
+            <template if:true={dealers}>
+                <div class="dealers-table-wrapper">
+                    <div class="dealers-table-header">
+                        <span class="header-rank">#</span>
+                        <span class="header-name">Dealer Name</span>
+                        <span class="header-metric">Amount Financed (MTD)</span>
+                    </div>
+                    <ul class="dealers-list">
+                        <template for:each={dealers} for:item="dealer">
+                            <li key={dealer.rank} class="dealer-item">
+                                <span class="dealer-rank">{dealer.rank}</span>
+                                <span class="dealer-name" title={dealer.Name}>
+                                    <template if:true={dealer.accountLink}>
+                                        <a href={dealer.accountLink} target="_blank" class="dealer-link-text">{dealer.Name}</a>
+                                    </template>
+                                    <template if:false={dealer.accountLink}>
+                                        {dealer.Name}
+                                    </template>
+                                </span>
+                                <span class="dealer-metric">{dealer.MetricFormatted}</span>
+                            </li>
+                        </template>
+                    </ul>
+                </div>
+            </template>
+
+            <template if:false={dealers}>
+                <div class="no-data-message">No dealer data available.</div>
+            </template>
+        </div>
     </div>
 </template>


### PR DESCRIPTION
## Summary
- Add unified header banner to Top Dealers, Dealer Watchlist, Dealer Detail, and Daily Call Goal components
- Restructure Daily Call Goal for full-width layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f8ac48448330a298ef29ce8dfbd2