### PR TITLE
Handle existing Monthly_Goal records in test setup

### DIFF
--- a/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
+++ b/BetaOne/force-app/main/default/classes/SalesDataServiceTest.cls
@@ -48,6 +48,9 @@ private class SalesDataServiceTest {
 
         insert records;
 
+        // Remove any existing monthly goal records to satisfy unique record validation
+        delete [SELECT Id FROM Monthly_Goal__c];
+
         Monthly_Goal__c goal = new Monthly_Goal__c(
             Region_Target_Alberta__c = 1000,
             Region_Target_Quebec__c = 2000,


### PR DESCRIPTION
## Summary
- clear any existing Monthly_Goal__c records in test setup to avoid validation failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894ff4bc914833082e631d43532fb9d