### PR TITLE
Add call goal dashboard component

### DIFF
--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.css
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.css
@@ -1,0 +1,317 @@
+:host {
+    display: block;
+}
+
+.dashboard {
+    min-height: 100vh;
+    background: linear-gradient(to bottom right, #f8fafc, #eff6ff);
+    padding: 1.5rem;
+}
+
+.dashboard-container {
+    max-width: 64rem;
+    margin: 0 auto;
+}
+
+.header {
+    background: linear-gradient(to right, #2563eb, #1d4ed8, #4338ca);
+    border-radius: 1rem 1rem 0 0;
+    padding: 1.5rem;
+    color: #fff;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.title {
+    display: flex;
+    align-items: center;
+}
+
+.icon-wrapper {
+    background: rgba(255, 255, 255, 0.2);
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    backdrop-filter: blur(4px);
+}
+
+.icon-white lightning-icon {
+    --sds-c-icon-color-foreground-default: #ffffff;
+}
+
+.title-text {
+    margin-left: 0.75rem;
+}
+
+.title-text h1 {
+    margin: 0;
+    font-size: 1.5rem;
+    font-weight: bold;
+}
+
+.title-text p {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #bfdbfe;
+}
+
+.user-button {
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    border: none;
+    cursor: pointer;
+}
+
+.user-button lightning-icon {
+    margin-right: 0.25rem;
+}
+
+.user-button lightning-icon:last-child {
+    margin-left: 0.25rem;
+    margin-right: 0;
+}
+
+.user-button:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.main {
+    background: #fff;
+    border-radius: 0 0 1rem 1rem;
+    padding: 2rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 3rem;
+}
+
+@media (min-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr 1fr;
+        align-items: center;
+    }
+}
+
+.progress-circle {
+    display: flex;
+    justify-content: center;
+}
+
+.circle-wrapper {
+    position: relative;
+    width: 16rem;
+    height: 16rem;
+}
+
+.circle-wrapper svg {
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.circle-bg {
+    stroke: #e5e7eb;
+    fill: transparent;
+}
+
+.circle-progress {
+    fill: transparent;
+    stroke: url(#gradient);
+    stroke-linecap: round;
+    transition: stroke-dashoffset 1s ease-out;
+}
+
+.circle-center {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.calls-count {
+    font-size: 3rem;
+    font-weight: bold;
+    color: #111827;
+}
+
+.calls-label {
+    color: #6b7280;
+    font-size: 0.875rem;
+}
+
+.calls-total {
+    color: #9ca3af;
+    font-size: 0.75rem;
+}
+
+.stats-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.stat-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    border: 1px solid;
+    transition: box-shadow 0.3s;
+}
+
+.stat-card:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.progress-card {
+    background: linear-gradient(to right, #f0fdf4, #dcfce7);
+    border-color: #bbf7d0;
+}
+
+.progress-card .stat-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.progress-card .stat-header span {
+    margin-left: 0.5rem;
+    color: #166534;
+    font-weight: 600;
+}
+
+.progress-card .stat-value {
+    font-size: 1.875rem;
+    font-weight: bold;
+    color: #065f46;
+    margin-bottom: 0.25rem;
+}
+
+.progress-card .stat-desc {
+    color: #16a34a;
+    font-size: 0.875rem;
+}
+
+.progress-card .stat-emoji {
+    width: 4rem;
+    height: 4rem;
+    background: #d1fae5;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+}
+
+.remaining-card {
+    background: linear-gradient(to right, #eff6ff, #e0e7ff);
+    border-color: #bfdbfe;
+}
+
+.remaining-card .stat-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.remaining-card .stat-header span {
+    margin-left: 0.5rem;
+    color: #1e3a8a;
+    font-weight: 600;
+}
+
+.remaining-card .stat-value {
+    font-size: 1.875rem;
+    font-weight: bold;
+    color: #1e40af;
+    margin-bottom: 0.25rem;
+}
+
+.remaining-card .stat-desc {
+    color: #2563eb;
+    font-size: 0.875rem;
+}
+
+.remaining-card .stat-emoji {
+    width: 4rem;
+    height: 4rem;
+    background: #dbeafe;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+}
+
+.motivation-card {
+    background: linear-gradient(to right, #faf5ff, #fdf2f8);
+    border: 1px solid #e9d5ff;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    text-align: center;
+}
+
+.motivation-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #4c1d95;
+    margin-bottom: 0.5rem;
+}
+
+.motivation-text {
+    color: #6b21a8;
+    font-size: 0.875rem;
+}
+
+.bottom-progress {
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #f3f4f6;
+}
+
+.progress-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.progress-label span:first-child {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #4b5563;
+}
+
+.progress-label span:last-child {
+    font-size: 0.875rem;
+    font-weight: bold;
+    color: #111827;
+}
+
+.progress-bar {
+    width: 100%;
+    background: #e5e7eb;
+    border-radius: 9999px;
+    height: 0.75rem;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(to right, #f97316, #f59e0b);
+    border-radius: 9999px;
+    transition: width 1s ease-out;
+}

--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.html
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.html
@@ -1,0 +1,103 @@
+<template>
+    <div class="dashboard app-container">
+        <div class="dashboard-container">
+            <div class="header">
+                <div class="header-content">
+                    <div class="title">
+                        <div class="icon-wrapper">
+                            <lightning-icon icon-name="utility:target" size="small" class="icon-white"></lightning-icon>
+                        </div>
+                        <div class="title-text">
+                            <h1>Daily Call Goal</h1>
+                            <p>Monitor daily calls against your goal</p>
+                        </div>
+                    </div>
+                    <div class="user-select">
+                        <button class="user-button">
+                            <lightning-icon icon-name="utility:user" size="x-small"></lightning-icon>
+                            <span>Ricky Palmero</span>
+                            <lightning-icon icon-name="utility:chevrondown" size="x-small"></lightning-icon>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="main">
+                <div class="content-grid">
+                    <div class="progress-circle">
+                        <div class="circle-wrapper">
+                            <svg viewBox="0 0 200 200">
+                                <circle cx="100" cy="100" r="85" stroke-width="12" class="circle-bg"></circle>
+                                <circle cx="100" cy="100" r="85" stroke-width="12" class="circle-progress" style={progressStyle}></circle>
+                                <defs>
+                                    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                                        <stop offset="0%" stop-color="#f97316" />
+                                        <stop offset="100%" stop-color="#f59e0b" />
+                                    </linearGradient>
+                                </defs>
+                            </svg>
+                            <div class="circle-center">
+                                <div class="calls-count">{completedCalls}</div>
+                                <div class="calls-label">calls</div>
+                                <div class="calls-total">of {totalCalls}</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="stats-cards">
+                        <div class="stat-card progress-card">
+                            <div class="stat-content">
+                                <div class="stat-header">
+                                    <lightning-icon icon-name="utility:trending" size="small" class="progress-icon"></lightning-icon>
+                                    <span>Progress</span>
+                                </div>
+                                <div class="stat-value">{percentage}%</div>
+                                <div class="stat-desc">Complete</div>
+                            </div>
+                            <div class="stat-emoji">📈</div>
+                        </div>
+
+                        <div class="stat-card remaining-card">
+                            <div class="stat-content">
+                                <div class="stat-header">
+                                    <lightning-icon icon-name="utility:call" size="small" class="remaining-icon"></lightning-icon>
+                                    <span>Remaining</span>
+                                </div>
+                                <div class="stat-value">{remaining}</div>
+                                <div class="stat-desc">Calls left</div>
+                            </div>
+                            <div class="stat-emoji">🎯</div>
+                        </div>
+
+                        <div class="motivation-card">
+                            <div class="motivation-message">
+                                <div class="motivation-title">
+                                    <template if:true={percentageGreaterEqual50}>Great progress!</template>
+                                    <template if:false={percentageGreaterEqual50}>Keep going!</template>
+                                </div>
+                                <div class="motivation-text">
+                                    <template if:true={percentageGreaterEqual50}>
+                                        You're over halfway to your daily goal! {remaining} calls to go.
+                                    </template>
+                                    <template if:false={percentageGreaterEqual50}>
+                                        You've got this! Just {remaining} more calls to reach your target.
+                                    </template>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="bottom-progress">
+                    <div class="progress-label">
+                        <span>Daily Progress</span>
+                        <span>{percentage}%</span>
+                    </div>
+                    <div class="progress-bar">
+                        <div class="progress-fill" style={progressBarStyle}></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js
@@ -1,0 +1,40 @@
+import { LightningElement } from 'lwc';
+import { loadUnifiedStyles } from 'c/unifiedStylesHelper';
+
+export default class CallGoalDashboard extends LightningElement {
+    totalCalls = 30;
+    completedCalls = 13;
+    radius = 85;
+
+    connectedCallback() {
+        loadUnifiedStyles(this);
+    }
+
+    get percentage() {
+        return Math.round((this.completedCalls / this.totalCalls) * 100);
+    }
+
+    get remaining() {
+        return this.totalCalls - this.completedCalls;
+    }
+
+    get circumference() {
+        return 2 * Math.PI * this.radius;
+    }
+
+    get strokeDashoffset() {
+        return this.circumference - (this.percentage / 100) * this.circumference;
+    }
+
+    get progressStyle() {
+        return `stroke-dasharray:${this.circumference}; stroke-dashoffset:${this.strokeDashoffset};`;
+    }
+
+    get progressBarStyle() {
+        return `width:${this.percentage}%`;
+    }
+
+    get percentageGreaterEqual50() {
+        return this.percentage >= 50;
+    }
+}

--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js-meta.xml
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__Tab</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__AppPage,lightning__HomePage">
+            <supportedFormFactors>
+                <supportedFormFactor type="Large"/>
+                <supportedFormFactor type="Small"/>
+            </supportedFormFactors>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION
## Summary
- add `callGoalDashboard` Lightning Web Component with progress circle, stat cards, motivational message, and bottom progress bar
- compute call metrics in JavaScript and style layout with gradients and responsive design

## Testing
- `npm run lint` *(fails: Restricted async operation "setTimeout" and other existing lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950c6d1cf88330add868587cd87693