### PR TITLE
feat: sync call goal dashboard with activity tracker

### DIFF
--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.css
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.css
@@ -38,7 +38,7 @@
     backdrop-filter: blur(4px);
 }
 
-.icon-white lightning-icon {
+.icon-white {
     --sds-c-icon-color-foreground-default: #ffffff;
 }
 
@@ -185,6 +185,19 @@
     display: flex;
     align-items: center;
     margin-bottom: 0.5rem;
+}
+
+.progress-card .stat-header lightning-icon,
+.remaining-card .stat-header lightning-icon {
+    margin-right: 0.5rem;
+}
+
+.progress-card .stat-header lightning-icon {
+    --sds-c-icon-color-foreground-default: #166534;
+}
+
+.remaining-card .stat-header lightning-icon {
+    --sds-c-icon-color-foreground-default: #1e3a8a;
 }
 
 .progress-card .stat-header span {

--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.html
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.html
@@ -15,7 +15,7 @@
                     <div class="user-select">
                         <button class="user-button">
                             <lightning-icon icon-name="utility:user" size="x-small"></lightning-icon>
-                            <span>Ricky Palmero</span>
+                            <span>{salespersonName}</span>
                             <lightning-icon icon-name="utility:chevrondown" size="x-small"></lightning-icon>
                         </button>
                     </div>

--- a/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js
+++ b/BetaOne/force-app/main/default/lwc/callGoalDashboard/callGoalDashboard.js
@@ -1,13 +1,63 @@
-import { LightningElement } from 'lwc';
+import { LightningElement, track } from 'lwc';
 import { loadUnifiedStyles } from 'c/unifiedStylesHelper';
+import getSalespeople from '@salesforce/apex/ActivityController.getSalespeople';
+import getActivityData from '@salesforce/apex/ActivityController.getActivityData';
 
 export default class CallGoalDashboard extends LightningElement {
+    @track salespeople = [];
+    @track selectedSalesperson = '';
+    @track salespersonName = '';
+
+    dailyGoal = 30;
     totalCalls = 30;
-    completedCalls = 13;
+    completedCalls = 0;
     radius = 85;
 
     connectedCallback() {
         loadUnifiedStyles(this);
+        this.loadSalespeople();
+    }
+
+    loadSalespeople() {
+        getSalespeople()
+            .then(result => {
+                this.salespeople = result;
+                if (result && result.length > 0) {
+                    this.selectedSalesperson = result[0].id;
+                    this.salespersonName = result[0].name;
+                    this.loadActivityData();
+                }
+            })
+            .catch(error => {
+                // eslint-disable-next-line no-console
+                console.error('Error loading salespeople', error);
+            });
+    }
+
+    loadActivityData() {
+        if (!this.selectedSalesperson) return;
+        const params = {
+            salespersonId: this.selectedSalesperson,
+            eventType: null,
+            timeframe: 'today'
+        };
+
+        getActivityData(params)
+            .then(result => {
+                const total = result.reduce(
+                    (sum, item) => sum + (item.totalActivities || 0),
+                    0
+                );
+                this.completedCalls = total;
+                this.totalCalls = this.dailyGoal;
+                if (result.length > 0) {
+                    this.salespersonName = result[0].salespersonName;
+                }
+            })
+            .catch(error => {
+                // eslint-disable-next-line no-console
+                console.error('Error loading activity data', error);
+            });
     }
 
     get percentage() {
@@ -15,7 +65,7 @@ export default class CallGoalDashboard extends LightningElement {
     }
 
     get remaining() {
-        return this.totalCalls - this.completedCalls;
+        return Math.max(this.totalCalls - this.completedCalls, 0);
     }
 
     get circumference() {
@@ -31,7 +81,7 @@ export default class CallGoalDashboard extends LightningElement {
     }
 
     get progressBarStyle() {
-        return `width:${this.percentage}%`;
+        return `width:${Math.min(this.percentage, 100)}%`;
     }
 
     get percentageGreaterEqual50() {


### PR DESCRIPTION
## Summary
- pull daily call totals from ActivityController so call goal dashboard matches activity tracker
- display salesperson name and align icon formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895121c959c8330996f4d5ab191f925