### PR TITLE
refine activity tracker styling

### DIFF
--- a/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.css
+++ b/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.css
@@ -14,3 +14,80 @@
     display: flex;
     flex-direction: column;
 }
+
+/* Enhanced styling for activity tracker */
+.metric-card {
+    background: var(--card-background-color);
+    border: 1px solid var(--border-light);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-large);
+}
+
+.chart-wrapper {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    margin: 0 auto;
+}
+
+.chart-svg {
+    width: 100%;
+    height: 100%;
+}
+
+.chart-center {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
+
+.calls-number {
+    font-size: 2rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--heading-color);
+}
+
+.calls-text {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+}
+
+.goal-text {
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+}
+
+.stats-row {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-large);
+    text-align: center;
+    margin-top: var(--spacing-large);
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-small);
+}
+
+.stat-number {
+    font-size: 1.5rem;
+    font-weight: var(--font-weight-semibold);
+    color: var(--heading-color);
+}
+
+.stat-number.complete {
+    color: var(--success-color);
+}
+
+.stat-number.over-goal {
+    color: var(--warning-color);
+}
+
+.stat-text {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+}

--- a/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.html
+++ b/BetaOne/force-app/main/default/lwc/activityTracker/activityTracker.html
@@ -35,10 +35,9 @@
 
             <!-- Main Display -->
             <template if:true={selectedSalespersonData}>
-                <!-- Donut Chart -->
-                <div class="chart-wrapper slds-text-align_center">
-                    <div style="position: relative; display: inline-block; max-width: 300px; margin: 0 auto;">
-                        <svg viewBox="0 0 120 120" class="chart-svg" style="width: 100%; height: auto;">
+                <div class="metric-card">
+                    <div class="chart-wrapper">
+                        <svg viewBox="0 0 120 120" class="chart-svg">
                         <defs>
                             <!-- Circular gradient that follows the arc -->
                             <linearGradient id="progressGradient" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -55,16 +54,16 @@
                                 <stop offset="100%" style="stop-color:#d97706;stop-opacity:1"/>
                             </linearGradient>
                         </defs>
-                        
+
                         <!-- Background circle -->
-                        <circle cx="60" cy="60" r="45" 
-                                fill="none" 
-                                stroke="#e5e7eb" 
+                        <circle cx="60" cy="60" r="45"
+                                fill="none"
+                                stroke="#e5e7eb"
                                 stroke-width="12"/>
-                        
+
                         <!-- Progress circle -->
-                        <circle cx="60" cy="60" r="45" 
-                                fill="none" 
+                        <circle cx="60" cy="60" r="45"
+                                fill="none"
                                 stroke={progressColor}
                                 stroke-width="14"
                                 stroke-linecap="round"
@@ -72,11 +71,11 @@
                                 stroke-dashoffset={progressOffset}
                                 transform="rotate(-90 60 60)"
                                 style="transition: stroke-dashoffset 0.5s ease-in-out, stroke 0.3s ease-in-out;"/>
-                                
+
                         <!-- Overflow circle -->
                         <template if:true={selectedSalespersonData.goalProgress.isOverGoal}>
-                            <circle cx="60" cy="60" r="45" 
-                                    fill="none" 
+                            <circle cx="60" cy="60" r="45"
+                                    fill="none"
                                     stroke="url(#goldGradient)"
                                     stroke-width="13"
                                     stroke-linecap="round"
@@ -86,36 +85,35 @@
                                     style="transition: stroke-dashoffset 0.5s ease-in-out;"/>
                         </template>
                     </svg>
-                    
+
                     <!-- Chart Center Content -->
-                    <div class="chart-center" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">
-                        <div class="calls-number" style="font-size: 2rem; font-weight: bold; color: #181818;">{selectedSalespersonData.goalProgress.calls}</div>
-                        <div class="calls-text" style="font-size: 0.875rem; color: #666;">calls</div>
-                        <div class="goal-text" style="font-size: 0.75rem; color: #999;">of {dailyGoal}</div>
+                    <div class="chart-center">
+                        <div class="calls-number">{selectedSalespersonData.goalProgress.calls}</div>
+                        <div class="calls-text">calls</div>
+                        <div class="goal-text">of {dailyGoal}</div>
                     </div>
                 </div>
-            </div>
-            
-            <!-- Stats -->
-            <div class="stats-row slds-grid slds-gutters_medium slds-text-align_center slds-m-top_large">
-                <div class="stat slds-col slds-size_1-of-2">
-                    <span class="stat-number slds-text-heading_large" style="color: #10b981; font-weight: bold;">{selectedSalespersonData.goalProgress.percentage}%</span>
-                    <div class="stat-text slds-text-body_small slds-text-color_weak">Complete</div>
+
+                <div class="stats-row">
+                    <div class="stat">
+                        <span class="stat-number complete">{selectedSalespersonData.goalProgress.percentage}%</span>
+                        <div class="stat-text">Complete</div>
+                    </div>
+                    <template if:false={selectedSalespersonData.goalProgress.isOverGoal}>
+                        <div class="stat">
+                            <span class="stat-number">{selectedSalespersonData.goalProgress.remaining}</span>
+                            <div class="stat-text">Remaining</div>
+                        </div>
+                    </template>
+                    <template if:true={selectedSalespersonData.goalProgress.isOverGoal}>
+                        <div class="stat">
+                            <span class="stat-number over-goal">+{overGoalCalls}</span>
+                            <div class="stat-text">Over Goal</div>
+                        </div>
+                    </template>
                 </div>
-                <template if:false={selectedSalespersonData.goalProgress.isOverGoal}>
-                    <div class="stat slds-col slds-size_1-of-2">
-                        <span class="stat-number slds-text-heading_large" style="color: #666; font-weight: bold;">{selectedSalespersonData.goalProgress.remaining}</span>
-                        <div class="stat-text slds-text-body_small slds-text-color_weak">Remaining</div>
-                    </div>
-                </template>
-                <template if:true={selectedSalespersonData.goalProgress.isOverGoal}>
-                    <div class="stat slds-col slds-size_1-of-2">
-                        <span class="stat-number over-goal slds-text-heading_large" style="color: #f59e0b; font-weight: bold;">+{overGoalCalls}</span>
-                        <div class="stat-text slds-text-body_small slds-text-color_weak">Over Goal</div>
-                    </div>
-                </template>
             </div>
-        </template>
+            </template>
 
         <!-- Empty State -->
         <template if:false={selectedSalespersonData}>


### PR DESCRIPTION
## Summary
- restyle activity tracker with card layout and CSS variables for charts and stats
- replace inline styles with classes for chart center and metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896225fe6188330a05490232c68352b